### PR TITLE
fix: GM3156 -> GM1356 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gm3156 (0.0.2)
+    gm1356 (0.0.2)
       hidapi (= 0.1.9)
 
 GEM
@@ -41,7 +41,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  gm3156!
+  gm1356!
   pry
   rubocop
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This driver was written for **Digital Sound Level Meter** with USB (type **GM135
 ## Installation
 First make sure you have `ruby` interpreter installed. Then run:
 
-```gem install gm3156```
+```gem install gm1356```
 
 Now make sure that `users` have access to your device. In my case I had to create `/etc/udev/rules.d/90-usbpermission.rules` with such content:
 
@@ -21,11 +21,11 @@ And after all reconnect your device if it was already connected.
 ## Usage
 If you want to print real time data from your sonometer, run:
 
-```gm3156```
+```gm1356```
 
 For more options:
 
-```gm3156 --help```
+```gm1356 --help```
 
 ## Protocol
 I used Wireshark with USBPcap to sniff communication between my device and SoundLab on Windows in order to understend the protocol. Protocol is described in [PROTOCOL.md](PROTOCOL.md).

--- a/bin/gm1356
+++ b/bin/gm1356
@@ -2,12 +2,12 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require_relative '../lib/gm3156'
+require_relative '../lib/gm1356'
 
 options = {}
 
 OptionParser.new do |opts|
-  opts.banner = 'Usage: gm3156 [options]'
+  opts.banner = 'Usage: gm1356 [options]'
 
   opts.on('-fFILTER', '--filter=FILTER', String, 'A/C filter') do |f|
     options[:filter] = :a if f.downcase == 'a'
@@ -37,7 +37,7 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-device = GM3156::Device.new(options)
+device = GM1356::Device.new(options)
 
 begin
   device.read do |record|

--- a/gm1356.gemspec
+++ b/gm1356.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |s|
-  s.name           = 'gm3156'
+  s.name           = 'gm1356'
   s.version        = '0.0.2'
   s.date           = '2019-05-31'
   s.summary        = 'Captures and prints data, supports editing settings.'
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email          = 'maciej.ciemborowicz+rubygems@gmail.com'
   s.files          = Dir['{lib}/**/*.rb', 'bin/*', '*.md']
   s.require_path   = 'lib'
-  s.executables    = ['gm3156']
+  s.executables    = ['gm1356']
   s.homepage       = 'https://github.com/ciembor/gm1356'
   s.license        = 'MIT'
   s.add_dependency 'hidapi', '= 0.1.9'

--- a/lib/gm1356.rb
+++ b/lib/gm1356.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GM1356
+  require_relative 'gm1356/errors'
+  require_relative 'gm1356/device'
+  require_relative 'gm1356/record'
+end

--- a/lib/gm1356/device.rb
+++ b/lib/gm1356/device.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GM3156
+module GM1356
   require 'hidapi'
   require_relative 'errors'
   require_relative 'settings'

--- a/lib/gm1356/errors.rb
+++ b/lib/gm1356/errors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GM3156
+module GM1356
   class InvalidCaptureDataLengthError < StandardError
     attr_reader :data
 

--- a/lib/gm1356/record.rb
+++ b/lib/gm1356/record.rb
@@ -14,8 +14,16 @@ module GM1356
       message[0..3].to_i(16).to_s.insert(-2, '.').to_f
     end
 
+    def filter
+      settings.filter.to_s.capitalize
+    end
+
+    def format
+      "dB#{filter}"
+    end
+
     def to_s
-      output = "#{timestamp.strftime('%H:%M:%S')} \t SPL: #{spl}dB#{settings.filter.to_s.capitalize}"
+      output = "#{timestamp.strftime('%H:%M:%S')} \t SPL: #{spl}#{format}"
       output += "\t MAX mode" if settings.max_mode
       output
     end

--- a/lib/gm1356/record.rb
+++ b/lib/gm1356/record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GM3156
+module GM1356
   require_relative 'settings'
 
   class Record

--- a/lib/gm1356/settings.rb
+++ b/lib/gm1356/settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GM3156
+module GM1356
   class Settings
     AVAILABLE_RANGES = [
       '30-120',

--- a/lib/gm3156.rb
+++ b/lib/gm3156.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module GM3156
-  require_relative 'gm3156/errors'
-  require_relative 'gm3156/device'
-  require_relative 'gm3156/record'
-end


### PR DESCRIPTION
I've also split out the logic used in `Record#to_s` 

```ruby
"... dB#{settings.filter.to_s.capitalize}"
```

into two methods: `Record#filter` & `Record#format`