### PR TITLE
fix: Device#read

### DIFF
--- a/lib/gm1356/device.rb
+++ b/lib/gm1356/device.rb
@@ -25,7 +25,7 @@ module GM1356
       loop do
         Thread.new do
           read_current_state(&block)
-        end
+        end.abort_on_exception = true
         sleep settings.speed == :fast? ? 0.5 : 1
       end
     end


### PR DESCRIPTION
Ensure the Thread aborts upon an exception.

---

@ciembor First of all, great work on putting this together 👍  I've been using it in a Ruby on Rails app to monitor sound levels, and I've been finding that after a period of time, the readings from the device stop. I have been unable to see a pattern as to what causes this. Making the change in this PR has allowed me to trackdown the exception as `LIBUSB::ERROR_NO_DEVICE in libusb_submit_transfer`

I'm now handling that by closing the device and starting again like so:

```ruby
    def perform
      Rails.logger.info "GM1356::Device New"
      device = GM1356::Device.new

      begin
        device.read do |record|
          # do work
        end
      rescue Exception => e
        Rails.logger.info "GM1356::Device Exception #{e}"
        raise
      ensure
        Rails.logger.info "Closing GM1356::Device"
        device.close

        Rails.logger.info "enqueue SoundMonitor"
        Resque.enqueue(SoundMonitor)
      end
    end
```

