### PR TITLE
puts makes the Output not Pipeable, with print the Output can be pars…

### DIFF
--- a/bin/gm1356
+++ b/bin/gm1356
@@ -41,7 +41,8 @@ device = GM1356::Device.new(options)
 
 begin
   device.read do |record|
-    puts record.to_s
+    print record.to_s
+    print "\n"
   end
 rescue Exception # rubocop:disable Lint/RescueException
   device.close


### PR DESCRIPTION
I don't know anything about ruby, but it seems puts Buffers the Output ,so piping
"|grep xy" doesn't work. With print the output can now be parsed