### PR TITLE
Added docker support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2.7.2-alpine
+
+RUN apk --update add --no-cache --virtual .dependencies build-base \
+ && gem install gm1356 \
+ && apk del .dependencies 
+
+CMD ["gm1356"]

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --no-cache -t gm1356 ./

--- a/docker/start
+++ b/docker/start
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run -it --privileged -v /dev/bus/usb:/dev/bus/usb gm1356


### PR DESCRIPTION
Hello @ciembor, 

I have a simple Dockerfile to support running your tool in a Docker container.

Usage: `cd docker; ./build && ./start`

Maybe you could merge it?


